### PR TITLE
_id can't be changed on Elastic v2, use _uid instead

### DIFF
--- a/src/output/elasticsearch.go
+++ b/src/output/elasticsearch.go
@@ -7,27 +7,25 @@ import (
 	"github.com/mcuadros/harvester/src/intf"
 )
 
-const ESIdField = "_id"
-
 type ElasticsearchConfig struct {
-	Host    string `default:"localhost" description:"elastic host port "`
-	Port    int    `default:"9200" description:"elastic search port "`
-	Index   string `description:"index name"`
-	Type    string `description:"index type"`
-	Timeout int    `default:"1" description:"contection timeout"`
-	IdField string `description:"the content of the given field will be copied into _id"`
+	Host     string `default:"localhost" description:"elastic host port "`
+	Port     int    `default:"9200" description:"elastic search port "`
+	Index    string `description:"index name"`
+	Type     string `description:"index type"`
+	Timeout  int    `default:"1" description:"contection timeout"`
+	UidField string `description:"copied as id into into _uid, which consists of 'type#id'"`
 }
 
 type Elasticsearch struct {
 	HTTP
-	idField string
+	uidField string
 }
 
 func NewElasticsearch(config *ElasticsearchConfig) *Elasticsearch {
 	defaults.SetDefaults(config)
 
 	output := new(Elasticsearch)
-	output.idField = config.IdField
+	output.uidField = config.UidField
 	output.SetConfig(output.TransformConfig(config))
 
 	return output
@@ -46,10 +44,6 @@ func (o *Elasticsearch) TransformConfig(config *ElasticsearchConfig) *HTTPConfig
 }
 
 func (o *Elasticsearch) PutRecord(record intf.Record) bool {
-	if o.idField != "" {
-		record[ESIdField] = record[o.idField]
-	}
-
 	return o.HTTP.PutRecord(record)
 }
 
@@ -61,8 +55,8 @@ func (o *Elasticsearch) getIndexURL(config *ElasticsearchConfig) string {
 		config.Type,
 	)
 
-	if o.idField != "" {
-		url = fmt.Sprintf("%s/%%{%s}", url, o.idField)
+	if o.uidField != "" {
+		url = fmt.Sprintf("%s/%%{%s}", url, o.uidField)
 	}
 
 	return url

--- a/src/output/elasticsearch_test.go
+++ b/src/output/elasticsearch_test.go
@@ -26,12 +26,12 @@ func (s *ElasticsearchSuite) TestGetRecordDefault(c *C) {
 }
 
 func (s *ElasticsearchSuite) TestGetRecordDefaultField(c *C) {
-	config := ElasticsearchConfig{Index: "foo", Type: "foo", IdField: "foo"}
+	config := ElasticsearchConfig{Index: "foo", Type: "foo", UidField: "foo"}
 
 	output := NewElasticsearch(&config)
 	record := intf.Record{"foo": "bar"}
 
-	go dummyServer(c, ":9200", "/foo/foo/bar", "application/json", "POST", "{\n     \"_id\": \"bar\",\n     \"foo\": \"bar\"\n }")
+	go dummyServer(c, ":9200", "/foo/foo/bar", "application/json", "POST", "{\n     \"foo\": \"bar\"\n }")
 	c.Assert(output.PutRecord(record), Equals, true)
 }
 


### PR DESCRIPTION
As explained on https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_20_mapping_changes.html:

> `_id`configuration can no longer be changed. If you need to sort, use the `_uid` field instead. 

Also, `_uid` is set via the URL:

> Importantly, **meta-fields can no longer be specified as part of the document body**. Instead, they must be specified in the query string parameters.
